### PR TITLE
Support URIs for grammars

### DIFF
--- a/src/instaparse/core.bb
+++ b/src/instaparse/core.bb
@@ -1,5 +1,7 @@
 (ns instaparse.core
-  (:require [babashka.pods :as pods]))
+  (:require
+   [babashka.pods :as pods]
+   [clojure.java.io :as io]))
 
 (pods/load-pod
  ;; for local dev:
@@ -71,8 +73,11 @@ something that can have a metamap attached."
   (parses [this & opts])
   (pod-ref [this]))
 
-(defn parser [& args]
-  (let [p (apply insta/parser args)]
+(defn parser [grammar & args]
+  (let [spec (cond
+               (instance? java.net.URL grammar) (slurp grammar)
+               :else grammar)
+        p (insta/parser spec args)]
     (reify
       clojure.lang.IFn
       (invoke [_ text] (insta/parse p text))


### PR DESCRIPTION
# The issue
According to the `instaparser.core/parser` docstring
> Takes a string specification of a context-free grammar,
  or a URI for a text file containing such a specification (Clj only),...

But in `instaparser-bb`, if the grammar is an URI object, then the call fails because the URI is not serializable...
```
clojure.lang.ExceptionInfo: java.lang.Exception: Not supported: class java.net.URL
```

# My solution
Slurp the grammar before calling the pod if if it is an URI object

Btw, thanks a lot for fixing most of the compatibility issues between `instaparser` and `babshka`!